### PR TITLE
possible fix for issue https://github.com/typeorm/typeorm/issues/5978

### DIFF
--- a/src/controller/post.ts
+++ b/src/controller/post.ts
@@ -24,7 +24,10 @@ export default class PostController {
       const user: User = await this.userRepository.findOne(userId);
       const newpost = <Post>request.payload;
       newpost.user = user
-      let post: Post = await this.postRepository.save(newpost);
+
+      const entityInstance = this.userRepository.create(newpost);
+
+      let post: Post = await this.postRepository.save(entityInstance);
       return new ResponseBuilder().setData(post);
     } catch (error) {
       console.log(error.stack);

--- a/src/controller/user.ts
+++ b/src/controller/user.ts
@@ -24,7 +24,8 @@ export default class UserController {
     const newUser = <User>request.payload;
 
     try {
-      let user: User = await this.userRepository.save(newUser);
+      const entityInstance = this.userRepository.create(newUser);
+      let user: User = await this.userRepository.save(entityInstance);
       return new ResponseBuilder().setData(user);
     } catch (error) {
       console.log(error.stack);


### PR DESCRIPTION
The problem is that you were saving user/post without `Entity instance` and without this both @ BeforeInsert and BeforeUpdate are not get called. 

I have managed to debug it via different project since I dont konw much about hapi. Incase you want t try it yourself i used jest and files are

hapi.test.ts
```
import {connectDb} from '../utils/test/testConnection';
import {UserRepository} from './userRepository';
import {getCustomRepository} from 'typeorm';
import {User} from '../entities/User';

connectDb();

describe('test', () => {

  it('should call validate using repository create', async function() {
    const userRepository = getCustomRepository(UserRepository);

    const result = await userRepository.createUser({
      firstName: 'string',
      lastName: 'string',
      age: 23
    });

    expect(result).toBeDefined();
  });

  it('should call validate using User.save()', async function(){
    const user = {
      firstName: 'string',
        lastName: 'string',
        age: 23
    };

    const result = await User.save(User.create(user));

    expect(result).toBeDefined();
  });
});
```

UserRepository.ts
```
@EntityRepository(User)
export class UserRepository extends Repository<User> {
  createUser(input: any) { //for testing only
    const user = this.create(input); //very important.
    return this.save(user);
  }
}
```

Few things to remember always save `Entity instance`. That can be easily archived by creating new instance of entity class like
```
 const user = new User();

    user.firstName = 'firstName';
    user.lastName = 'lastName';
    user.age = 39;

    const result = await User.save(user);
```
or by using typeorm `create `method like 
```
    const userObj = {
      firstName: 'string',
      lastName: 'string',
      age: 23
    };

    const user = User.create(userObj);
    const result = await User.save(user);

```
